### PR TITLE
Move to swift 3 and create a protocol interface

### DIFF
--- a/ApplicationEventObserver.xcodeproj/project.pbxproj
+++ b/ApplicationEventObserver.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 				TargetAttributes = {
 					4DB0C55A1C302328000154F4 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -243,6 +244,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -260,6 +262,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.sgrksmt.ApplicationEventObserver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/ApplicationEventObserver/ApplicationEventObserver.swift
+++ b/ApplicationEventObserver/ApplicationEventObserver.swift
@@ -74,7 +74,7 @@ public struct ApplicationEvent {
         NSNotification.Name.UIApplicationDidChangeStatusBarFrame:        UIApplicationStatusBarFrameUserInfoKey
     ]
     
-    public init?(notification: Notification) {
+    public init?(notification: Foundation.Notification) {
         guard let type = ApplicationEventType(notificationName: notification.name) else {
             return nil
         }

--- a/ApplicationEventObserver/ApplicationEventObserver.swift
+++ b/ApplicationEventObserver/ApplicationEventObserver.swift
@@ -25,18 +25,18 @@ public enum ApplicationEventType {
     case backgroundRefreshStatusDidChange
     
     fileprivate static let eventTypes: [NSNotification.Name: ApplicationEventType] = [
-        NSNotification.Name.UIApplicationDidFinishLaunching:               .didFinishLaunching,
-        NSNotification.Name.UIApplicationWillEnterForeground:              .willEnterForeground,
-        NSNotification.Name.UIApplicationDidEnterBackground:               .didEnterBackground,
-        NSNotification.Name.UIApplicationWillResignActive:                 .willResignActive,
-        NSNotification.Name.UIApplicationDidBecomeActive:                  .didBecomeActive,
-        NSNotification.Name.UIApplicationDidReceiveMemoryWarning:          .didReceiveMemoryWarning,
-        NSNotification.Name.UIApplicationWillTerminate:                    .willTerminate,
-        NSNotification.Name.UIApplicationSignificantTimeChange:            .significantTimeChange,
-        NSNotification.Name.UIApplicationWillChangeStatusBarOrientation:   .willChangeStatusBarOrientation,
-        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation:    .didChangeStatusBarOrientation,
-        NSNotification.Name.UIApplicationWillChangeStatusBarFrame:         .willChangeStatusBarFrame,
-        NSNotification.Name.UIApplicationDidChangeStatusBarFrame:          .didChangeStatusBarFrame,
+        NSNotification.Name.UIApplicationDidFinishLaunching: .didFinishLaunching,
+        NSNotification.Name.UIApplicationWillEnterForeground: .willEnterForeground,
+        NSNotification.Name.UIApplicationDidEnterBackground: .didEnterBackground,
+        NSNotification.Name.UIApplicationWillResignActive: .willResignActive,
+        NSNotification.Name.UIApplicationDidBecomeActive: .didBecomeActive,
+        NSNotification.Name.UIApplicationDidReceiveMemoryWarning: .didReceiveMemoryWarning,
+        NSNotification.Name.UIApplicationWillTerminate: .willTerminate,
+        NSNotification.Name.UIApplicationSignificantTimeChange: .significantTimeChange,
+        NSNotification.Name.UIApplicationWillChangeStatusBarOrientation: .willChangeStatusBarOrientation,
+        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation: .didChangeStatusBarOrientation,
+        NSNotification.Name.UIApplicationWillChangeStatusBarFrame: .willChangeStatusBarFrame,
+        NSNotification.Name.UIApplicationDidChangeStatusBarFrame: .didChangeStatusBarFrame,
         NSNotification.Name.UIApplicationBackgroundRefreshStatusDidChange: .backgroundRefreshStatusDidChange
     ]
     
@@ -101,7 +101,7 @@ public protocol ApplicationEventObserverProtocol {
 
 open class ApplicationEventObserver: ApplicationEventObserverProtocol {
     
-    fileprivate lazy var nc = NotificationCenter.default
+    fileprivate lazy var nc: NotificationCenter = NotificationCenter.default
     
     fileprivate var callBack: ApplicationEventBlock?
 

--- a/ApplicationEventObserver/ApplicationEventObserver.swift
+++ b/ApplicationEventObserver/ApplicationEventObserver.swift
@@ -10,52 +10,52 @@ import Foundation
 import UIKit
 
 public enum ApplicationEventType {
-    case DidFinishLaunching
-    case WillEnterForeground
-    case DidEnterBackground
-    case WillResignActive
-    case DidBecomeActive
-    case DidReceiveMemoryWarning
-    case WillTerminate
-    case SignificantTimeChange
-    case WillChangeStatusBarOrientation
-    case DidChangeStatusBarOrientation
-    case WillChangeStatusBarFrame
-    case DidChangeStatusBarFrame
-    case BackgroundRefreshStatusDidChange
+    case didFinishLaunching
+    case willEnterForeground
+    case didEnterBackground
+    case willResignActive
+    case didBecomeActive
+    case didReceiveMemoryWarning
+    case willTerminate
+    case significantTimeChange
+    case willChangeStatusBarOrientation
+    case didChangeStatusBarOrientation
+    case willChangeStatusBarFrame
+    case didChangeStatusBarFrame
+    case backgroundRefreshStatusDidChange
     
-    private static let eventTypes: [String: ApplicationEventType] = [
-        UIApplicationDidFinishLaunchingNotification:               .DidFinishLaunching,
-        UIApplicationWillEnterForegroundNotification:              .WillEnterForeground,
-        UIApplicationDidEnterBackgroundNotification:               .DidEnterBackground,
-        UIApplicationWillResignActiveNotification:                 .WillResignActive,
-        UIApplicationDidBecomeActiveNotification:                  .DidBecomeActive,
-        UIApplicationDidReceiveMemoryWarningNotification:          .DidReceiveMemoryWarning,
-        UIApplicationWillTerminateNotification:                    .WillTerminate,
-        UIApplicationSignificantTimeChangeNotification:            .SignificantTimeChange,
-        UIApplicationWillChangeStatusBarOrientationNotification:   .WillChangeStatusBarOrientation,
-        UIApplicationDidChangeStatusBarOrientationNotification:    .DidChangeStatusBarOrientation,
-        UIApplicationWillChangeStatusBarFrameNotification:         .WillChangeStatusBarFrame,
-        UIApplicationDidChangeStatusBarFrameNotification:          .DidChangeStatusBarFrame,
-        UIApplicationBackgroundRefreshStatusDidChangeNotification: .BackgroundRefreshStatusDidChange
+    fileprivate static let eventTypes: [NSNotification.Name: ApplicationEventType] = [
+        NSNotification.Name.UIApplicationDidFinishLaunching:               .didFinishLaunching,
+        NSNotification.Name.UIApplicationWillEnterForeground:              .willEnterForeground,
+        NSNotification.Name.UIApplicationDidEnterBackground:               .didEnterBackground,
+        NSNotification.Name.UIApplicationWillResignActive:                 .willResignActive,
+        NSNotification.Name.UIApplicationDidBecomeActive:                  .didBecomeActive,
+        NSNotification.Name.UIApplicationDidReceiveMemoryWarning:          .didReceiveMemoryWarning,
+        NSNotification.Name.UIApplicationWillTerminate:                    .willTerminate,
+        NSNotification.Name.UIApplicationSignificantTimeChange:            .significantTimeChange,
+        NSNotification.Name.UIApplicationWillChangeStatusBarOrientation:   .willChangeStatusBarOrientation,
+        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation:    .didChangeStatusBarOrientation,
+        NSNotification.Name.UIApplicationWillChangeStatusBarFrame:         .willChangeStatusBarFrame,
+        NSNotification.Name.UIApplicationDidChangeStatusBarFrame:          .didChangeStatusBarFrame,
+        NSNotification.Name.UIApplicationBackgroundRefreshStatusDidChange: .backgroundRefreshStatusDidChange
     ]
     
-    public var notificationName: String {
-        return self.dynamicType.eventTypes
+    public var notificationName: NSNotification.Name? {
+        return type(of: self).eventTypes
             .flatMap{ $0.1 == self ? $0.0 : nil }
-            .first ?? ""
+            .first ?? nil
     }
     
     public static var allEventTypes: [ApplicationEventType] {
         return eventTypes.values.map { $0 }
     }
     
-    public static var allNotificationNames: [String] {
+    public static var allNotificationNames: [NSNotification.Name] {
         return eventTypes.keys.map { $0 }
     }
     
-    public init?(notificationName name: String) {
-        guard let type = self.dynamicType.eventTypes[name] else {
+    public init?(notificationName name: NSNotification.Name) {
+        guard let type = type(of: self).eventTypes[name] else {
             return nil
         }
         self = type
@@ -64,17 +64,17 @@ public enum ApplicationEventType {
 }
 
 public struct ApplicationEvent {
-    private(set) public var type: ApplicationEventType
-    private(set) public var value: AnyObject?
+    fileprivate(set) public var type: ApplicationEventType
+    fileprivate(set) public var value: Any?
     
-    private static let notificationValueKeys: [String: String]  = [
-        UIApplicationWillChangeStatusBarOrientationNotification: UIApplicationStatusBarOrientationUserInfoKey,
-        UIApplicationDidChangeStatusBarOrientationNotification:  UIApplicationStatusBarOrientationUserInfoKey,
-        UIApplicationWillChangeStatusBarFrameNotification:       UIApplicationStatusBarFrameUserInfoKey,
-        UIApplicationDidChangeStatusBarFrameNotification:        UIApplicationStatusBarFrameUserInfoKey
+    fileprivate static let notificationValueKeys: [NSNotification.Name: String]  = [
+        NSNotification.Name.UIApplicationWillChangeStatusBarOrientation: UIApplicationStatusBarOrientationUserInfoKey,
+        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation:  UIApplicationStatusBarOrientationUserInfoKey,
+        NSNotification.Name.UIApplicationWillChangeStatusBarFrame:       UIApplicationStatusBarFrameUserInfoKey,
+        NSNotification.Name.UIApplicationDidChangeStatusBarFrame:        UIApplicationStatusBarFrameUserInfoKey
     ]
     
-    public init?(notification: NSNotification) {
+    public init?(notification: Notification) {
         guard let type = ApplicationEventType(notificationName: notification.name) else {
             return nil
         }
@@ -82,25 +82,33 @@ public struct ApplicationEvent {
         self.type = type
         
         if let
-            key = self.dynamicType.notificationValueKeys[notification.name],
-            value = notification.userInfo?[key] {
+            key = type(of: self).notificationValueKeys[notification.name],
+            let value = notification.userInfo?[key] {
             self.value = value
         }
     }
 }
 
-public typealias ApplicationEventBlock = ApplicationEvent -> Void
+public typealias ApplicationEventBlock = (ApplicationEvent) -> Void
 
-public class ApplicationEventObserver {
-    
-    private lazy var nc = NSNotificationCenter.defaultCenter()
-    
-    private var callBack: ApplicationEventBlock?
+public protocol ApplicationEventObserverProtocol {
 
-    private var enabled: Bool = false
+    func subscribe(_ callBack: @escaping ApplicationEventBlock)
+    func dispose()
+    func resume()
+    func suspend()
+}
+
+open class ApplicationEventObserver: ApplicationEventObserverProtocol {
+    
+    fileprivate lazy var nc = NotificationCenter.default
+    
+    fileprivate var callBack: ApplicationEventBlock?
+
+    fileprivate var enabled: Bool = false
     public init() {
         ApplicationEventType.allNotificationNames.forEach {
-            nc.addObserver(self, selector: "notified:", name: $0, object: nil)
+            nc.addObserver(self, selector: #selector(ApplicationEventObserver.notified(_:)), name: $0, object: nil)
         }
     }
     
@@ -109,27 +117,27 @@ public class ApplicationEventObserver {
         nc.removeObserver(self)
     }
     
-    public func subscribe(callBack: ApplicationEventBlock) {
+    open func subscribe(_ callBack: @escaping ApplicationEventBlock) {
         self.callBack = callBack
         resume()
     }
     
-    public func dispose() {
+    open func dispose() {
         suspend()
         self.callBack = nil
     }
     
-    public func resume() {
+    open func resume() {
         enabled = true
     }
     
-    public func suspend() {
+    open func suspend() {
         enabled = false
     }
 }
 
 private extension ApplicationEventObserver {
-    @objc private func notified(notification: NSNotification) {
+    @objc func notified(_ notification: Notification) {
         if !enabled { return }
         guard let event = ApplicationEvent(notification: notification) else {
             return

--- a/ApplicationEventObserver/ApplicationEventObserver.swift
+++ b/ApplicationEventObserver/ApplicationEventObserver.swift
@@ -137,7 +137,7 @@ open class ApplicationEventObserver: ApplicationEventObserverProtocol {
 }
 
 private extension ApplicationEventObserver {
-    @objc func notified(_ notification: Notification) {
+    @objc func notified(_ notification: Foundation.Notification) {
         if !enabled { return }
         guard let event = ApplicationEvent(notification: notification) else {
             return

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 				TargetAttributes = {
 					4D488EB71C4EA039004AEF02 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -277,6 +278,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.sgr-ksmt.Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -288,6 +290,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.sgr-ksmt.Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -16,11 +16,11 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view, typically from a nib.
         observer.subscribe() { event in
             switch event.type {
-            case .DidBecomeActive, .WillResignActive:
-                print(event.type.notificationName)
-            case .WillChangeStatusBarFrame:
+            case .didBecomeActive, .willResignActive:
+                print(event.type.notificationName?.rawValue)
+            case .willChangeStatusBarFrame:
                 if let v = event.value {
-                    print(event.type.notificationName)
+                    print(event.type.notificationName?.rawValue)
                     print(v)
                 }
             default: break


### PR DESCRIPTION
- Performs the swift migration
- Moves away from strings, preferring the `NSNotification.Name` type
- Creates a protocol for easy mocking of lifecycle events in unit tests