### PR TITLE
Update to Swift 5 (and 4.2)

### DIFF
--- a/ApplicationEventObserver.xcodeproj/project.pbxproj
+++ b/ApplicationEventObserver.xcodeproj/project.pbxproj
@@ -97,16 +97,17 @@
 				TargetAttributes = {
 					4DB0C55A1C302328000154F4 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 4DB0C5551C302328000154F4 /* Build configuration list for PBXProject "ApplicationEventObserver" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 4DB0C5511C302328000154F4;
 			productRefGroup = 4DB0C55C1C302328000154F4 /* Products */;
@@ -244,7 +245,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -262,7 +263,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.sgrksmt.ApplicationEventObserver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/ApplicationEventObserver.xcodeproj/project.pbxproj
+++ b/ApplicationEventObserver.xcodeproj/project.pbxproj
@@ -97,7 +97,7 @@
 				TargetAttributes = {
 					4DB0C55A1C302328000154F4 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -244,7 +244,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -262,7 +262,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.sgrksmt.ApplicationEventObserver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/ApplicationEventObserver/ApplicationEventObserver.swift
+++ b/ApplicationEventObserver/ApplicationEventObserver.swift
@@ -64,14 +64,14 @@ public enum ApplicationEventType {
 }
 
 public struct ApplicationEvent {
-    fileprivate(set) public var type: ApplicationEventType
-    fileprivate(set) public var value: Any?
+    public let type: ApplicationEventType
+    public let value: Any?
     
     fileprivate static let notificationValueKeys: [NSNotification.Name: String]  = [
         NSNotification.Name.UIApplicationWillChangeStatusBarOrientation: UIApplicationStatusBarOrientationUserInfoKey,
-        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation:  UIApplicationStatusBarOrientationUserInfoKey,
-        NSNotification.Name.UIApplicationWillChangeStatusBarFrame:       UIApplicationStatusBarFrameUserInfoKey,
-        NSNotification.Name.UIApplicationDidChangeStatusBarFrame:        UIApplicationStatusBarFrameUserInfoKey
+        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation: UIApplicationStatusBarOrientationUserInfoKey,
+        NSNotification.Name.UIApplicationWillChangeStatusBarFrame: UIApplicationStatusBarFrameUserInfoKey,
+        NSNotification.Name.UIApplicationDidChangeStatusBarFrame: UIApplicationStatusBarFrameUserInfoKey
     ]
     
     public init?(notification: Foundation.Notification) {
@@ -81,10 +81,15 @@ public struct ApplicationEvent {
         
         self.type = type
         
-        if let
-            key = type(of: self).notificationValueKeys[notification.name],
+        if
+            let key = type(of: self).notificationValueKeys[notification.name],
             let value = notification.userInfo?[key] {
+
             self.value = value
+
+        } else {
+
+            self.value = nil
         }
     }
 }

--- a/ApplicationEventObserver/ApplicationEventObserver.swift
+++ b/ApplicationEventObserver/ApplicationEventObserver.swift
@@ -23,7 +23,7 @@ public enum ApplicationEventType {
     case willChangeStatusBarFrame
     case didChangeStatusBarFrame
     case backgroundRefreshStatusDidChange
-    
+
     fileprivate static let eventTypes: [NSNotification.Name: ApplicationEventType] = [
         NSNotification.Name.UIApplicationDidFinishLaunching: .didFinishLaunching,
         NSNotification.Name.UIApplicationWillEnterForeground: .willEnterForeground,
@@ -39,48 +39,48 @@ public enum ApplicationEventType {
         NSNotification.Name.UIApplicationDidChangeStatusBarFrame: .didChangeStatusBarFrame,
         NSNotification.Name.UIApplicationBackgroundRefreshStatusDidChange: .backgroundRefreshStatusDidChange
     ]
-    
+
     public var notificationName: NSNotification.Name? {
         return type(of: self).eventTypes
-            .flatMap{ $0.1 == self ? $0.0 : nil }
+            .flatMap { $0.1 == self ? $0.0 : nil }
             .first ?? nil
     }
-    
+
     public static var allEventTypes: [ApplicationEventType] {
         return eventTypes.values.map { $0 }
     }
-    
+
     public static var allNotificationNames: [NSNotification.Name] {
         return eventTypes.keys.map { $0 }
     }
-    
+
     public init?(notificationName name: NSNotification.Name) {
         guard let type = type(of: self).eventTypes[name] else {
             return nil
         }
         self = type
     }
-    
+
 }
 
 public struct ApplicationEvent {
     public let type: ApplicationEventType
     public let value: Any?
-    
+
     fileprivate static let notificationValueKeys: [NSNotification.Name: String]  = [
         NSNotification.Name.UIApplicationWillChangeStatusBarOrientation: UIApplicationStatusBarOrientationUserInfoKey,
         NSNotification.Name.UIApplicationDidChangeStatusBarOrientation: UIApplicationStatusBarOrientationUserInfoKey,
         NSNotification.Name.UIApplicationWillChangeStatusBarFrame: UIApplicationStatusBarFrameUserInfoKey,
         NSNotification.Name.UIApplicationDidChangeStatusBarFrame: UIApplicationStatusBarFrameUserInfoKey
     ]
-    
+
     public init?(notification: Foundation.Notification) {
         guard let type = ApplicationEventType(notificationName: notification.name) else {
             return nil
         }
-        
+
         self.type = type
-        
+
         if
             let key = type(of: self).notificationValueKeys[notification.name],
             let value = notification.userInfo?[key] {
@@ -105,9 +105,9 @@ public protocol ApplicationEventObserverProtocol {
 }
 
 open class ApplicationEventObserver: ApplicationEventObserverProtocol {
-    
+
     fileprivate lazy var nc: NotificationCenter = NotificationCenter.default
-    
+
     fileprivate var callBack: ApplicationEventBlock?
 
     fileprivate var enabled: Bool = false
@@ -116,26 +116,26 @@ open class ApplicationEventObserver: ApplicationEventObserverProtocol {
             nc.addObserver(self, selector: #selector(ApplicationEventObserver.notified(_:)), name: $0, object: nil)
         }
     }
-    
+
     deinit {
         dispose()
         nc.removeObserver(self)
     }
-    
+
     open func subscribe(_ callBack: @escaping ApplicationEventBlock) {
         self.callBack = callBack
         resume()
     }
-    
+
     open func dispose() {
         suspend()
         self.callBack = nil
     }
-    
+
     open func resume() {
         enabled = true
     }
-    
+
     open func suspend() {
         enabled = false
     }

--- a/ApplicationEventObserver/ApplicationEventObserver.swift
+++ b/ApplicationEventObserver/ApplicationEventObserver.swift
@@ -25,24 +25,24 @@ public enum ApplicationEventType {
     case backgroundRefreshStatusDidChange
 
     fileprivate static let eventTypes: [NSNotification.Name: ApplicationEventType] = [
-        NSNotification.Name.UIApplicationDidFinishLaunching: .didFinishLaunching,
-        NSNotification.Name.UIApplicationWillEnterForeground: .willEnterForeground,
-        NSNotification.Name.UIApplicationDidEnterBackground: .didEnterBackground,
-        NSNotification.Name.UIApplicationWillResignActive: .willResignActive,
-        NSNotification.Name.UIApplicationDidBecomeActive: .didBecomeActive,
-        NSNotification.Name.UIApplicationDidReceiveMemoryWarning: .didReceiveMemoryWarning,
-        NSNotification.Name.UIApplicationWillTerminate: .willTerminate,
-        NSNotification.Name.UIApplicationSignificantTimeChange: .significantTimeChange,
-        NSNotification.Name.UIApplicationWillChangeStatusBarOrientation: .willChangeStatusBarOrientation,
-        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation: .didChangeStatusBarOrientation,
-        NSNotification.Name.UIApplicationWillChangeStatusBarFrame: .willChangeStatusBarFrame,
-        NSNotification.Name.UIApplicationDidChangeStatusBarFrame: .didChangeStatusBarFrame,
-        NSNotification.Name.UIApplicationBackgroundRefreshStatusDidChange: .backgroundRefreshStatusDidChange
+        UIApplication.didFinishLaunchingNotification: .didFinishLaunching,
+        UIApplication.willEnterForegroundNotification: .willEnterForeground,
+        UIApplication.didEnterBackgroundNotification: .didEnterBackground,
+        UIApplication.willResignActiveNotification: .willResignActive,
+        UIApplication.didBecomeActiveNotification: .didBecomeActive,
+        UIApplication.didReceiveMemoryWarningNotification: .didReceiveMemoryWarning,
+        UIApplication.willTerminateNotification: .willTerminate,
+        UIApplication.significantTimeChangeNotification: .significantTimeChange,
+        UIApplication.willChangeStatusBarOrientationNotification: .willChangeStatusBarOrientation,
+        UIApplication.didChangeStatusBarOrientationNotification: .didChangeStatusBarOrientation,
+        UIApplication.willChangeStatusBarFrameNotification: .willChangeStatusBarFrame,
+        UIApplication.didChangeStatusBarFrameNotification: .didChangeStatusBarFrame,
+        UIApplication.backgroundRefreshStatusDidChangeNotification: .backgroundRefreshStatusDidChange
     ]
 
     public var notificationName: NSNotification.Name? {
         return type(of: self).eventTypes
-            .flatMap { $0.1 == self ? $0.0 : nil }
+            .compactMap { $0.1 == self ? $0.0 : nil }
             .first ?? nil
     }
 
@@ -68,10 +68,10 @@ public struct ApplicationEvent {
     public let value: Any?
 
     fileprivate static let notificationValueKeys: [NSNotification.Name: String]  = [
-        NSNotification.Name.UIApplicationWillChangeStatusBarOrientation: UIApplicationStatusBarOrientationUserInfoKey,
-        NSNotification.Name.UIApplicationDidChangeStatusBarOrientation: UIApplicationStatusBarOrientationUserInfoKey,
-        NSNotification.Name.UIApplicationWillChangeStatusBarFrame: UIApplicationStatusBarFrameUserInfoKey,
-        NSNotification.Name.UIApplicationDidChangeStatusBarFrame: UIApplicationStatusBarFrameUserInfoKey
+        UIApplication.willChangeStatusBarOrientationNotification: UIApplication.statusBarOrientationUserInfoKey,
+        UIApplication.didChangeStatusBarOrientationNotification: UIApplication.statusBarOrientationUserInfoKey,
+        UIApplication.willChangeStatusBarFrameNotification: UIApplication.statusBarFrameUserInfoKey,
+        UIApplication.didChangeStatusBarFrameNotification: UIApplication.statusBarFrameUserInfoKey
     ]
 
     public init?(notification: Foundation.Notification) {
@@ -82,7 +82,7 @@ public struct ApplicationEvent {
         self.type = type
 
         if
-            let key = type(of: self).notificationValueKeys[notification.name],
+            let key = Swift.type(of: self).notificationValueKeys[notification.name],
             let value = notification.userInfo?[key] {
 
             self.value = value

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -40,7 +40,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
 }
-

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
-        observer.subscribe() { event in
+        observer.subscribe { event in
             switch event.type {
             case .didBecomeActive, .willResignActive:
                 print(event.type.notificationName?.rawValue)
@@ -32,7 +32,4 @@ class ViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-
-
 }
-


### PR DESCRIPTION
This PR follows running the Swift 4.2 and Swift 5 update helpers in XCode 10.1 and XCode 10.2.1. There were no code changes between Swift 4.2 and 5 (only a few project file warnings).

This should therefore support both versions of Swift.

Bonus fixes:

- Improves / simplifies the `ApplicationEvent` initializer (`type` and `value` are now plain old `let`s)
- Fixes up a bunch of trailing whitespace and bonus newlines

